### PR TITLE
Don't let index go further than size of allFiles in HamshahriReader

### DIFF
--- a/JHazm/src/JHazm/HamshahriReader.java
+++ b/JHazm/src/JHazm/HamshahriReader.java
@@ -100,6 +100,10 @@ public class HamshahriReader {
             if (!isOpen) {
                 do {
                     index++;
+                    if (index >= allFiles.size()) {
+                        yieldBreak();
+                        return;
+                    }
                     file = new File(allFiles.get(index));
                 } while (getInvalidFiles().contains(file.getName()));
             }


### PR DESCRIPTION
من با یک زیرمجموعه از دیتاست همشهری دارم کار می‌کنم. در واقع فولدر ۱۹۹۶ از همشهری ۲. از اونجا که آخرین فایل این فولدر توی لیست فایل‌های ایگنورشده است، کد ریدر همشهری سعی می‌کنه فایل بعدی رو بخونه که موفق نمی‌شه چون فایل‌ها تموم شده‌ن.
